### PR TITLE
Fix contact form action URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # plumbmonkey-site
 Static website for Plumbmonkey Studio Services—Tailwind-powered landing, portfolio, and contact form.
+
+The “Hire Me” form sends submissions to [Formspree](https://formspree.io/f/xjkrragg).

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
   <section id="contact" class="py-24 bg-zinc-900">
     <div class="container mx-auto px-6">
       <h2 class="text-3xl font-semibold mb-6">Hire Me</h2>
-      <form action="https://formspree.io/f/xyzabc" method="POST" class="max-w-xl">
+      <form action="https://formspree.io/f/xjkrragg" method="POST" class="max-w-xl">
         <div class="mb-4">
           <label class="block mb-1">Name</label>
           <input type="text" name="name" required class="w-full p-3 rounded bg-zinc-800 border border-zinc-700" />


### PR DESCRIPTION
## Summary
- update Formspree action URL in Hire Me section
- document new form endpoint in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f5dba3d58832a9abba8267fce80a7