### PR TITLE
Add responsive mobile nav toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,13 +31,21 @@
   <header class="fixed top-0 inset-x-0 bg-zinc-900/80 backdrop-blur-sm z-50">
     <div class="container mx-auto flex items-center justify-between p-4">
       <a href="/" class="text-xl font-bold">Plumbmonkey</a>
-      <nav class="space-x-6">
-        <a href="#about" class="hover:underline">About</a>
-        <a href="#services" class="hover:underline">Services</a>
-        <a href="#work" class="hover:underline">Work</a>
-        <a href="#contact" class="hover:underline">Hire Me</a>
-        <a href="YOUR_DIRECTORY_URL" target="_blank" rel="noopener" class="hover:underline">Directory</a>
-      </nav>
+      <button id="menu-toggle" class="sm:hidden p-2" aria-expanded="false" aria-controls="nav-container">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        <span class="sr-only">Toggle navigation</span>
+      </button>
+      <div id="nav-container" class="hidden absolute top-full left-0 w-full bg-zinc-900/90 flex flex-col items-center space-y-6 sm:relative sm:flex sm:flex-row sm:space-y-0 sm:space-x-6 sm:bg-transparent sm:w-auto">
+        <nav>
+          <a href="#about" class="block px-2 hover:underline">About</a>
+          <a href="#services" class="block px-2 hover:underline">Services</a>
+          <a href="#work" class="block px-2 hover:underline">Work</a>
+          <a href="#contact" class="block px-2 hover:underline">Hire Me</a>
+          <a href="YOUR_DIRECTORY_URL" target="_blank" rel="noopener" class="block px-2 hover:underline">Directory</a>
+        </nav>
+      </div>
     </div>
   </header>
 
@@ -141,6 +149,13 @@
 </footer>
 
   <script>
+    const menuToggle = document.getElementById('menu-toggle');
+    const navContainer = document.getElementById('nav-container');
+    menuToggle.addEventListener('click', () => {
+      const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
+      menuToggle.setAttribute('aria-expanded', !expanded);
+      navContainer.classList.toggle('hidden');
+    });
     document.querySelectorAll('a[href^="#"]').forEach(a=>{
       a.onclick=e=>{
         e.preventDefault();


### PR DESCRIPTION
## Summary
- add hamburger toggle button
- hide nav on small screens and add overlay styles
- toggle nav with JavaScript on button click

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685011c3ff64832a82192fde2f806a42